### PR TITLE
Ensure volume file permissions are correct

### DIFF
--- a/start-znc
+++ b/start-znc
@@ -27,5 +27,7 @@ if [ ! -f "${DATADIR}/configs/znc.conf" ]; then
   cp /src/znc.conf.default "${DATADIR}/configs/znc.conf"
 fi
 
+chown -R znc:znc "$DATADIR"
+
 # Start ZNC.
 exec znc --foreground --datadir="$DATADIR" $@


### PR DESCRIPTION
Volumes are mounted as root:root. As recommended at 
https://groups.google.com/forum/#!msg/docker-user/-q-bwfsvuJE/pIVCPCRiniAJ
we should chown the volume before using it
