### PR TITLE
Split /tmp/bootstrap.sh chmod and exec commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ MAINTAINER  Jim Myhrberg "contact@jimeh.me"
 # We use a bootstrap script to avoid having temporary cache files and build
 # dependencies being committed and included into the docker image.
 ADD         bootstrap.sh /tmp/
-RUN         chmod +x /tmp/bootstrap.sh && /tmp/bootstrap.sh
+RUN         chmod +x /tmp/bootstrap.sh
+RUN         /tmp/bootstrap.sh
 
 RUN         useradd znc
 ADD         start-znc /usr/local/bin/


### PR DESCRIPTION
When I ran the original I got the following error:

    Step 3 : RUN chmod +x /tmp/bootstrap.sh && /tmp/bootstrap.sh
     ---> Running in 62f54b7a5e6d
    /bin/sh: 1: /tmp/bootstrap.sh: Text file busy

Splitting the two commands up seems to give the text file enough time to finish up. I suppose a slight sleep could also be added inbetween the two commands if one was worried about creating too many images.