### PR TITLE
More verbosity on start and ca-certificates package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV ZNC_VERSION 1.6.1
 
 RUN apt-get update \
     && apt-get install -y sudo wget build-essential libssl-dev libperl-dev \
-               pkg-config swig3.0 libicu-dev \
+               pkg-config swig3.0 libicu-dev ca-certificates \
     && mkdir -p /src \
     && cd /src \
     && wget "http://znc.in/releases/archive/znc-${ZNC_VERSION}.tar.gz" \

--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ Make note of the use of `-i` and `-t` instead of `-d`. This attaches us to the
 container, so we can interact with ZNC's makepass process. With `-d` it would
 simply run in the background.
 
+## A note about ZNC 1.6
+
+Starting with version 1.6, ZNC now requires ssl/tls certificate verification!
+This means that it will *not* connect to your IRC server(s) if they don't
+present a valid certificate. This is meant to help keep you safer from
+MitM attacks.
+
+This image installs the debian/ubuntu `ca-certificates`
+[package](http://packages.ubuntu.com/vivid/ca-certificates) so that servers
+with valid certificates will automatically be connected to ensuring no additional
+user intervention needed. If one of your servers doesn't have a valid fingerprint,
+you will need to connect to your bouncer and respond to `*status`.
+
+See [this](https://mikaela.info/english/2015/02/24/znc160-ssl.html) article for more information.
 
 ## Building It Yourself
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,6 +13,7 @@ if [ -d "${DATADIR}/modules" ]; then
 
   # Build modules.
   for module in $modules; do
+    echo "Building module $module..."
     cd "$(dirname "$module")"
     znc-buildmod "$module"
   done
@@ -23,13 +24,16 @@ fi
 
 # Create default config if it doesn't exist
 if [ ! -f "${DATADIR}/configs/znc.conf" ]; then
+  echo "Creating a default configuration..."
   mkdir -p "${DATADIR}/configs"
   cp /znc.conf.default "${DATADIR}/configs/znc.conf"
 fi
 
 # Make sure $DATADIR is owned by znc user. This effects ownership of the
 # mounted directory on the host machine too.
+echo "Setting necessary permissions..."
 chown -R znc:znc "$DATADIR"
 
 # Start ZNC.
+echo "Starting ZNC..."
 exec sudo -u znc znc --foreground --datadir="$DATADIR" $@


### PR DESCRIPTION
I've added some simple echo statements so users know whats going on when the image starts (if they are attached/watching the log). This is especially helpful when checking to ensure a module builds.

Also, because I had to go through the painful process, I've added the ca-certificates package so servers with proper certificates will be connected to without a problem. I've added the necessary documentation about this 1.6 change and some links as well.

Lastly, I want to mention that docker image is awesome! Thanks a lot to jimeh for creating it!