### PR TITLE
Disable ipv6 by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
     && wget "http://znc.in/releases/archive/znc-${ZNC_VERSION}.tar.gz" \
     && tar -zxf "znc-${ZNC_VERSION}.tar.gz" \
     && cd "znc-${ZNC_VERSION}" \
-    && ./configure \
+    && ./configure --disable-ipv6 \
     && make \
     && make install \
     && apt-get remove -y wget \


### PR DESCRIPTION
Since Docker doesn't install ipv6 iptables rules by default, we probably shouldn't build with it on.

Fixes #15.