### PR TITLE
Use alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 # version 1.6.1-2
 # docker-version 1.11.1
-FROM ubuntu:15.04
+FROM alpine:3.3
 MAINTAINER Jim Myhrberg "contact@jimeh.me"
 
 ENV ZNC_VERSION 1.6.1
 
-RUN apt-get update \
-    && apt-get install -y sudo wget build-essential libssl-dev libperl-dev \
-               pkg-config swig3.0 libicu-dev ca-certificates \
+RUN apk add --no-cache sudo bash autoconf automake gettext-dev make g++ \
+	       openssl-dev pkgconfig perl-dev swig zlib-dev ca-certificates \
     && mkdir -p /src \
     && cd /src \
     && wget "http://znc.in/releases/archive/znc-${ZNC_VERSION}.tar.gz" \
@@ -16,12 +15,10 @@ RUN apt-get update \
     && ./configure --disable-ipv6 \
     && make \
     && make install \
-    && apt-get remove -y wget \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /src* /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/cache/apk/*
 
-RUN useradd znc
+RUN adduser -S znc
+RUN addgroup -S znc
 ADD docker-entrypoint.sh /entrypoint.sh
 ADD znc.conf.default /znc.conf.default
 RUN chmod 644 /znc.conf.default


### PR DESCRIPTION
As many official docker images have migrated over to alpine linux (https://www.brianchristner.io/docker-is-moving-to-alpine-linux/), I thought it would be good to use it for znc as well. 

The main benefit of this is reducing the image size. The existing image size is about 410Mb. With alpine, the image size is about 269Mb (about 45% reduction).

It could be reduced even further if I know what libs I could delete after compiling ZNC. If you have any suggestion there, that'd be great.

I am also not sure if there are any good ways to test that this change. I've run the container off of it and was able to get to the web admin page.

/cc @jimeh 
