### PR TITLE
Updated ZNC version to 1.6.3 and base image to Ubuntu 16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-# version 1.6.1-2
+# version 1.6.3
 # docker-version 1.11.1
 FROM ubuntu:15.04
 MAINTAINER Jim Myhrberg "contact@jimeh.me"
 
-ENV ZNC_VERSION 1.6.1
+ENV ZNC_VERSION 1.6.3
 
 RUN apt-get update \
     && apt-get install -y sudo wget build-essential libssl-dev libperl-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # version 1.6.3
 # docker-version 1.11.1
-FROM ubuntu:15.04
+FROM ubuntu:16.04
 MAINTAINER Jim Myhrberg "contact@jimeh.me"
 
 ENV ZNC_VERSION 1.6.3

--- a/znc.conf.default
+++ b/znc.conf.default
@@ -8,7 +8,7 @@
 // But if you feel risky, you might want to read help on /znc saveconfig and /znc rehash.
 // Also check http://en.znc.in/wiki/Configuration
 
-Version = 1.6.1
+Version = 1.6.3
 <Listener l>
         Port = 6667
         IPv4 = true


### PR DESCRIPTION
I updated both znc version and base image version. I think that especially the upgrade of the base image is really necessary since Ubuntu 15.04 is no longer supported by Canonical and it will not receive security updates anymore. I already tried to build the image with the changes on my server and all goes fine.
