### PR TITLE
bump ZNC and Ubuntu versions for security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # version 1.6.1-2
 # docker-version 1.11.1
-FROM ubuntu:15.04
+FROM ubuntu:18.04
 MAINTAINER Jim Myhrberg "contact@jimeh.me"
 
-ENV ZNC_VERSION 1.6.1
+ENV ZNC_VERSION 1.7.3
 
 RUN apt-get update \
     && apt-get install -y sudo wget build-essential libssl-dev libperl-dev \


### PR DESCRIPTION
upgrade base to Ubuntu 18.04 (Bionic Beaver), 15.04 was EoL on April 23, 2015
upgrade ZNC to 1.7.3, versions prior are vulnerable to CVE-2019-9917